### PR TITLE
Allow for setting dynamic duration

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -86,9 +86,10 @@ function showToast(props: {
   title?: JSX.Element
   description?: JSX.Element
   variant?: ToastVariant
+  duration?: number
 }) {
   toaster.show((data) => (
-    <Toast toastId={data.toastId} variant={props.variant}>
+    <Toast toastId={data.toastId} variant={props.variant} duration={props.duration}>
       <div class="grid gap-1">
         {props.title && <ToastTitle>{props.title}</ToastTitle>}
         {props.description && <ToastDescription>{props.description}</ToastDescription>}


### PR DESCRIPTION
Kobalte allows for setting/overriding the default 5000ms duration by passing a duration prop to the component.

https://kobalte.dev/docs/core/components/toast#toaster