### PR TITLE
Fix Copy Button behaviour

### DIFF
--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,8 +1,7 @@
 import type { Component } from "solid-js"
-import { Show, createEffect, createSignal, splitProps } from "solid-js"
+import { Show, createEffect, createSignal, on, splitProps } from "solid-js"
 
 import { As } from "@kobalte/core"
-import type { ToggleButtonRootState } from "@kobalte/core/dist/types/toggle-button"
 import { TbCheck, TbCopy } from "solid-icons/tb"
 
 import type { ToggleProps } from "~/components/ui/toggle"
@@ -19,33 +18,41 @@ const CopyButton: Component<CopyButtonProps> = (props) => {
   const [, rest] = splitProps(props, ["class", "content"])
   const [isCopied, setCopied] = createSignal(false)
 
-  createEffect(() => {
-    copyToClipboard(props.content)
-    setTimeout(() => {
-      setCopied(false)
-    }, 2000)
-  })
+  createEffect(
+    on(
+      isCopied,
+      () => {
+        if (isCopied()) {
+          copyToClipboard(props.content)
+          setTimeout(() => {
+            setCopied(false)
+          }, 2000)
+        }
+      },
+      { defer: true }
+    )
+  )
 
   return (
-    <Tooltip placement="top">
-      <TooltipTrigger asChild>
-        <As
-          component={Toggle}
-          onChange={setCopied}
-          pressed={isCopied()}
-          disabled={isCopied()}
-          class={cn("p-2", props.class)}
-          {...rest}
-        >
-          {(state: ToggleButtonRootState) => (
-            <Show when={state.pressed()} fallback={<TbCopy class="h-6 w-6" />}>
+    <>
+      <Tooltip placement="top">
+        <TooltipTrigger asChild>
+          <As
+            component={Toggle}
+            onChange={setCopied}
+            pressed={isCopied()}
+            disabled={isCopied()}
+            class={cn("p-2", props.class)}
+            {...rest}
+          >
+            <Show when={isCopied()} fallback={<TbCopy class="h-6 w-6" />}>
               <TbCheck class="h-6 w-6" />
             </Show>
-          )}
-        </As>
-      </TooltipTrigger>
-      <TooltipContent>{isCopied() ? `Copied!` : `Copy to Clipboard`}</TooltipContent>
-    </Tooltip>
+          </As>
+        </TooltipTrigger>
+        <TooltipContent>{isCopied() ? `Copied!` : `Copy to Clipboard`}</TooltipContent>
+      </Tooltip>
+    </>
   )
 }
 


### PR DESCRIPTION
### 📝 PR Description

This PR addresses the unexpected behaviour of the `CopyButton` component, ensuring that content copying occurs only when intended and the button state resets appropriately.

#### **Current Behaviour**
- Upon visiting pages that use the `CopyButton` component, their contents get copied immediately. This happens because the `createEffect` runs without any delay or checks.
- The component maintains its state and does not reset because the button's pressed state remains unchanged.

#### **Changes Made**
- Adjusted the `createEffect` to run explicitly when the `isCopied` signal changes. This ensures that copying happens at the intended time.
- Added a `deferred` prop set to `true` to prevent the `createEffect` from running on the initial render.
- Introduced a conditional check around the copy behaviour. Given that our `setInterval` is resetting the `isCopied` signal, this ensures that the copy action only happens when it should.

### 🚀 How to Test

1. Navigate to any page using the `CopyButton` component.
2. Ensure that content does not get copied immediately upon loading.
3. Interact with the `CopyButton` and verify that the content is copied as expected.
4. Wait for 2 seconds and ensure the button resets its state.
